### PR TITLE
Use fish-mode and fish-completion from Doom

### DIFF
--- a/init.el
+++ b/init.el
@@ -73,7 +73,7 @@
        vc                ; version-control and Emacs, sitting in a tree
 
        :term
-       ;;eshell            ; the elisp shell that works everywhere
+       eshell            ; the elisp shell that works everywhere
        ;;shell             ; simple shell REPL for Emacs
        ;;term              ; basic terminal emulator for Emacs
        vterm             ; the best terminal emulation in Emacs
@@ -163,7 +163,7 @@
        ;;rust              ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
        ;; scala             ; java, but good
        ;;(scheme +guile)   ; a fully conniving family of lisps
-       sh                ; she sells {ba,z,fi}sh shells on the C xor
+       (sh +fish)        ; she sells {ba,z,fi}sh shells on the C xor
        ;;sml
        ;;solidity          ; do you need a blockchain? No.
        ;;swift             ; who asked for emoji variables?

--- a/packages.el
+++ b/packages.el
@@ -72,8 +72,6 @@
 (package! erc)
 (package! f)
 (package! fira-code-mode)
-(package! fish-completion)
-(package! fish-mode)
 (package! flycheck)
 (package! flymake-easy)
 (package! gotham-theme)


### PR DESCRIPTION
`fish-mode` is enabled by `(sh +fish)` and `fish-completion` is enabled when both `eshell` and `company` modules are enabled. 

https://github.com/doomemacs/doomemacs/blob/master/modules/lang/sh/README.org
https://github.com/doomemacs/doomemacs/blob/master/modules/term/eshell/README.org